### PR TITLE
Remove build errors on Windows

### DIFF
--- a/extensions/mongo/plugins/lock_hash/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.lockhash)
-target_link_libraries(tests.catapult.test.mongo.plugins.lockhash catapult.plugins.lockhash.deps catapult.mongo.plugins.lockhash)
+target_link_libraries(tests.catapult.test.mongo.plugins.lockhash catapult.plugins.lockhash.deps)

--- a/extensions/mongo/plugins/lock_secret/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.locksecret)
-target_link_libraries(tests.catapult.test.mongo.plugins.locksecret catapult.plugins.locksecret.deps catapult.mongo.plugins.locksecret)
+target_link_libraries(tests.catapult.test.mongo.plugins.locksecret catapult.plugins.locksecret.deps)


### PR DESCRIPTION
With these changes: https://github.com/NewCapital/catapult-server/commit/d1e059a0079debea166297f62e7d83be55b04f35 and https://github.com/NewCapital/catapult-server/commit/330aa927487217249d5afa999ea1d2a56de5d505 project lost its cross-platform.

More about build errors on Windows here - https://github.com/symbol/catapult-client/pull/211